### PR TITLE
fix null reference error on nexus

### DIFF
--- a/Data/Scripts/PaintGun/Features/Palette/Palette.cs
+++ b/Data/Scripts/PaintGun/Features/Palette/Palette.cs
@@ -437,6 +437,9 @@ namespace Digi.PaintGun.Features.Palette
             if(!Main.CheckPlayerField.Ready)
                 return;
 
+            if (MyAPIGateway.Session.Player == null)
+                return;
+
             List<Vector3> newColors = MyAPIGateway.Session.Player.BuildColorSlots;
             IReadOnlyList<Vector3> storedColors = LocalInfo.ColorsMasks;
 


### PR DESCRIPTION
This commit fixes one of errors reported by "seamless plugin" users. There's a brief moment during seamless transition where local player is not assigned, which causes mod to fail and display an error message on the screen.

I know there are some other errors but couldn't reproduce today.